### PR TITLE
k8s workflow tests

### DIFF
--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -21,11 +21,11 @@ jobs:
       with:
         version: '>= 363.0.0'
 
-    # - uses: 'google-github-actions/auth@v2'
-    #   with:
-    #     credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-    #     project_id: 'prj-polygonlabs-devtools-dev'
-    #     service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+        project_id: 'prj-polygonlabs-devtools-dev'
+        service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
 
     - name: Install kubectl
       run: |

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -45,8 +45,6 @@ jobs:
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
         cd polygon-devnets/kubernetes/pos
-        echo "${{ secrets.GOOGLE_CREDENTIALS }}" > /tmp/credentials.json
-        gcloud auth activate-service-account ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --key-file=/tmp/credentials.json --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
-        echo '${{ secrets.GOOGLE_CREDENTIALS }}' | base64 --decode > /tmp/credentials.json
+        echo ${{ secrets.GOOGLE_CREDENTIALS }} > /tmp/credentials.json
         echo "$(< /tmp/credentials.json | head -c 10)"
         gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
         echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > /tmp/cluster_credentials.yaml
+        export KUBECONFIG=/tmp/cluster_credentials.yaml
         cd polygon-devnets/kubernetes/pos
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -44,9 +44,12 @@ jobs:
 
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
-        cd polygon-devnets/kubernetes/pos
-        gcloud auth login --no-launch-browser
+        echo '${{ secrets.GOOGLE_CREDENTIALS }}' | base64 --decode > /tmp/credentials.json
+        echo "$(< /tmp/credentials.json | head -c 10)"
+        gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
+        
+        cd polygon-devnets/kubernetes/pos
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace
         kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -1,87 +1,60 @@
-name: Deploy Devnet
-on: [ push, pull_request ]
+name: K8S DEVNET - REGRESSION DETECTOR
+on:
+  push:
+  release:
+    types: [prereleased]
 
 jobs:
   deploy_devnet:
     runs-on: ubuntu-latest
     steps:
-    - name: Maximize runner build space for k8s images
-      uses: AdityaGarg8/remove-unwanted-software@v2
-      with:
-        remove-android: 'true'
-        remove-dotnet: 'true'
-        remove-haskell: 'true'
-        remove-codeql: 'true'
-        remove-docker-images: 'true'
-    - name: Checkout curent repository
+    - name: Checkout repository
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.before }}
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+
     - name: Set up Docker
       uses: docker/setup-buildx-action@v1
-    - name: 'Set up Cloud SDK'
+
+    - name: Setup Google Cloud SDK
       uses: 'google-github-actions/setup-gcloud@v2'
       with:
         version: '>= 363.0.0'
-    - name: Install kubectl
-      run: |
-        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-        && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl \
-        && kubectl version --client
-    - name: Install kind
-      run: go install sigs.k8s.io/kind@v0.20.0
-    - name: Install tomlq
-      run: |
-        pip3 install tomlq
-    - name: Free github runner disk space for k8s image building
-      run: |
-        rm -rf /usr/share/dotnet/
-        rm -rf /opt/hostedtoolcache
+
     - uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-    - name: Clone, build, and load k8s devnet images
+
+    - name: Install kubectl
+      run: |
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+        && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+    - name: Install tomlq for config file preparation
+      run: |
+        pip3 install tomlq
+
+    - name: Clone private polygon-devnets repo
       run: |
         eval `ssh-agent -s`
         ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY }}'
-        git clone git@github.com:maticnetwork/polygon-devnets.git
-        cd polygon-devnets/docker/pos
-        make all DEV=true K8S_ENV=true K8S_NS=test
-        IMAGES=$(docker images -q)
-        echo $IMAGES
-        gcloud auth configure-docker europe-west2-docker.pkg.dev -q
-        for IMAGE_ID in $IMAGES; do
-          IMAGE_NAME=$(docker inspect --format='{{index .RepoTags 0}}' $IMAGE_ID)
-          sudo -u $USER docker push "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/container/${IMAGE_NAME}:latest"
+        git clone -b fix/pos_k8s_devnets git@github.com:maticnetwork/polygon-devnets.git
+
+    - name: Deploy PoS devnet to isolated GKE namespace
+      run: |
+        cd polygon-devnets/kubernetes/pos
+        # metrics must be tagged by unique namespace (devnet name / pre-release id)
+        # deployment must also create custom monitors by namespace
+        kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+
+    - name: Auto-apply load and report any regressions here
+      run: |
+        current_minute=$(date +'%M')
+        end_minute=$((current_minute + 60)) # Corrected the missing closing parenthesis
+        
+        while [ $current_minute -lt $end_minute ]; do
+          # TODO: call datadog API and get composite monitor status
+          echo "REGRESSION TESTING RESULTS... PRINTED HERE... "
+          sleep 600
+          current_minute=$(date +'%M')
         done
-    # - name: Create local k8s cluster
-    #   run: |
-    #     kind create cluster --name regression-tester --config .github/workflows/kind-config.yaml.sample
-    #     kubectl cluster-info --context kind-regression-tester
-    # - name: Clone and then build devnet images
-    #   run: |
-    #     eval `ssh-agent -s`
-    #     ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY }}'
-    #     git clone git@github.com:maticnetwork/polygon-devnets.git
-    #     cd polygon-devnets/docker/pos
-    #     make all DEV=true K8S_ENV=true K8S_NS=test
-    # - name: Load images into cluster
-    #   run: kind load docker-image ganache:latest heimdall:latest bor:latest workload:latest status:latest --name regression-tester
-    # - name: Deploy devnet
-    #   run: |
-    #     cd polygon-devnets/docker/pos/k8s
-    #     kubectl apply -k . --context kind-regression-tester
-    # - name: Check deployed resources
-    #   run: |
-    #     current_minute=$(date +'%M')
-    #     end_minute=$((current_minute + 60)) # Run for the next hour as test
-    # 
-    #     while [ $current_minute -lt $end_minute ]; do
-    #       kubectl get pods -n test
-    #       sleep 600 # Sleep for 10 minutes
-    #       current_minute=$(date +'%M')
-    #     done

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -62,12 +62,12 @@ jobs:
     #     export KUBECONFIG=~/.kube/regression-cluster.yaml
     #     kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
     # 
-    # - name: Finally, deploy datadog-agent via helm chart
-    #   run: |
-    #     cd panoptichain/terraform
-    #     terraform init
-    #     terraform apply -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
-    # 
+    - name: Finally, deploy datadog-agent via helm chart
+      run: |
+        cd panoptichain/terraform
+        terraform init
+        terraform apply -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+    
     # - name: Auto-apply load and report any regressions here
     #   run: |
     #     MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
@@ -87,7 +87,7 @@ jobs:
     #       echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
     #       sleep 60
     #     done
-    # 
+    
     #   # After stress tests, cleanup all ephemeral K8S devnet resources    
     # - name: Remove panoptichain, prometheus, and grafana resources
     #   run: |
@@ -102,22 +102,16 @@ jobs:
       run: |
         cd panoptichain/terraform
         retries=3
-        delay=180
+        delay=5
         count=0
         while [ $count -lt $retries ]; do
           terraform init
-          destroy_output=$(terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${DATADOG_API_KEY}" -var="coralogix_api_key=${CORALOGIX_API_KEY}" 2>&1)
-          if echo "$destroy_output" | grep -q "Still destroying"; then
-            echo "Destroy operation is still in progress. Retrying in $delay seconds..."
-            sleep $delay
-          elif echo "$destroy_output" | grep -q "Apply complete! Resources: 0 added, 0 changed, 1 destroyed"; then
-            echo "Datadog agent resources successfully destroyed."
+          terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${DATADOG_API_KEY}" -var="coralogix_api_key=${CORALOGIX_API_KEY}"
+          if [ $? -eq 0 ]; then
             break
-          else
-            echo "Destroy operation failed. Retrying in $delay seconds..."
-            count=$((count+1))
-            sleep $delay
           fi
+          count=$((count+1))
+          sleep $delay
         done
     
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -66,7 +66,7 @@ jobs:
     #   run: |
     #     cd panoptichain/terraform
     #     terraform init
-    #     terraform apply -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+    #     terraform apply -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
     # 
     # - name: Auto-apply load and report any regressions here
     #   run: |
@@ -99,7 +99,7 @@ jobs:
       run: |        
         cd panoptichain/terraform
         terraform init
-        terraform destroy -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+        terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
 
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment
       run: |     

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -21,11 +21,11 @@ jobs:
       with:
         version: '>= 363.0.0'
 
-    - uses: 'google-github-actions/auth@v2'
-      with:
-        credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-        project_id: 'prj-polygonlabs-devtools-dev'
-        service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
+    # - uses: 'google-github-actions/auth@v2'
+    #   with:
+    #     credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+    #     project_id: 'prj-polygonlabs-devtools-dev'
+    #     service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
 
     - name: Install kubectl
       run: |
@@ -44,11 +44,7 @@ jobs:
 
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
-        echo '${{ secrets.GOOGLE_CREDENTIALS }}' > /tmp/credentials.json
-        echo "$(< /tmp/credentials.json | head -c 10)"
-        # gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
-        gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
-        
+        echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > /tmp/cluster_credentials.yaml
         cd polygon-devnets/kubernetes/pos
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -77,7 +77,7 @@ jobs:
         DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
         DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
     
-        end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
+        end_minute=$(( $(date +'%M') + 10))  # Calculate the end minute, bake time, make configurable..
     
         while [ $(date +'%M') -lt $end_minute ]; do
           STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -43,6 +43,8 @@ jobs:
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
         cd polygon-devnets/kubernetes/pos
+        echo "${{ secrets.GOOGLE_CREDENTIALS }}" > /tmp/credentials.json
+        gcloud auth activate-service-account ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --key-file=/tmp/credentials.json --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
-        echo ${{ secrets.GOOGLE_CREDENTIALS }} > /tmp/credentials.json
+        echo '${{ secrets.GOOGLE_CREDENTIALS }}' > /tmp/credentials.json
         echo "$(< /tmp/credentials.json | head -c 10)"
         gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -99,7 +99,7 @@ jobs:
       run: |        
         cd panoptichain/terraform
         terraform init
-        terraform delete -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+        terraform destroy -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
 
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment
       run: |     

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -40,24 +40,49 @@ jobs:
         eval `ssh-agent -s`
         ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY }}'
         git clone -b fix/pos_k8s_devnets git@github.com:maticnetwork/polygon-devnets.git
+        
+    - name: Clone private panoptichain repo
+      run: |
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY_PANOPTICHAIN }}'
+        git clone -b dan/k8s_panoptichain git@github.com:0xPolygon/panoptichain.git
 
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
-        echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > /tmp/cluster_credentials.yaml
-        export KUBECONFIG=/tmp/cluster_credentials.yaml
+        mkdir -p ~/.kube
+        echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
         cd polygon-devnets/kubernetes/pos
-        # metrics must be tagged by unique namespace (devnet name / pre-release id)
-        # deployment must also create custom monitors by namespace
         kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        
+    - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
+      run: |
+        cd panoptichain
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        
+    - name: Finally, deploy datadog-agent via helm chart
+      run: |
+        cd panoptichain/terraform
+        terraform init
+        terraform apply -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
 
     - name: Auto-apply load and report any regressions here
       run: |
+        MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
+        DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
+        DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
+
         current_minute=$(date +'%M')
-        end_minute=$((current_minute + 60)) # Corrected the missing closing parenthesis
+        end_minute=$((current_minute + 60))
         
         while [ $current_minute -lt $end_minute ]; do
-          # TODO: call datadog API and get composite monitor status
-          echo "REGRESSION TESTING RESULTS... PRINTED HERE... "
-          sleep 600
+          STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
+                    -H "Content-Type: application/json" \
+                    -H "DD-API-KEY: ${DATADOG_API_KEY}" \
+                    -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
+                    -s \
+                    | jq -r '.overall_state')
+          echo "K8S DEVNET HEALTH STATUS: $STATUS"
           current_minute=$(date +'%M')
         done

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -48,11 +48,11 @@ jobs:
         ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY_PANOPTICHAIN }}'
         git clone -b dan/k8s_panoptichain git@github.com:0xPolygon/panoptichain.git
 
-    # - name: Deploy PoS devnet to isolated GKE namespace
-    #   run: |
-    #     mkdir -p ~/.kube
-    #     echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
-    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
+    - name: Deploy PoS devnet to isolated GKE namespace
+      run: |
+        mkdir -p ~/.kube
+        echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
     #     cd polygon-devnets/kubernetes/pos
     #     kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
     # 

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
         project_id: 'prj-polygonlabs-devtools-dev'
-        service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
 
     - name: Install kubectl and gcloud kubectl auth plugin
       run: |

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
         cd polygon-devnets/kubernetes/pos
+        gcloud auth login --no-launch-browser
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -96,7 +96,12 @@ jobs:
     #     kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 
     - name: Remove all datadog agent resources
-      run: |        
+      register: tf_result
+      retries: 3
+      delay: 5
+      until: tf_result is not failed
+      ansible.builtin.shell:
+        cmd: |
         cd panoptichain/terraform
         terraform init
         terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
@@ -106,4 +111,3 @@ jobs:
         cd polygon-devnets/kubernetes/pos
         export KUBECONFIG=~/.kube/regression-cluster.yaml
         kubectl delete -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -102,9 +102,9 @@ jobs:
       until: tf_result is not failed
       ansible.builtin.shell:
         cmd: |
-        cd panoptichain/terraform
-        terraform init
-        terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+          cd panoptichain/terraform
+          terraform init
+          terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
 
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment
       run: |     

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -74,7 +74,7 @@ jobs:
         DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
 
         current_minute=$(date +'%M')
-        end_minute=$((current_minute + 60))
+        end_minute=$((current_minute + 10))
         
         while [ $current_minute -lt $end_minute ]; do
           STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
@@ -84,6 +84,25 @@ jobs:
                     -s \
                     | jq -r '.overall_state')
           echo "K8S DEVNET HEALTH STATUS: $STATUS"
+          echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
           current_minute=$(date +'%M')
           sleep 60
         done
+        
+    - name: After stress tests, cleanup all ephemeral K8S devnet resources
+      run: |
+        # remove panoptichain, prometheus, and grafana resources
+        cd panoptichain
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        
+        # remove all datadog agent resources
+        cd panoptichain/terraform
+        terraform init
+        terraform delete -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+        
+        # finally, remove all pos devnet resources to return to clean slate GKE environment
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        cd polygon-devnets/kubernetes/pos
+        kubectl delete -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -48,60 +48,62 @@ jobs:
         ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY_PANOPTICHAIN }}'
         git clone -b dan/k8s_panoptichain git@github.com:0xPolygon/panoptichain.git
 
-    - name: Deploy PoS devnet to isolated GKE namespace
-      run: |
-        mkdir -p ~/.kube
-        echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
-        export KUBECONFIG=~/.kube/regression-cluster.yaml
-        cd polygon-devnets/kubernetes/pos
-        kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-        
-    - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
-      run: |
-        cd panoptichain
-        export KUBECONFIG=~/.kube/regression-cluster.yaml
-        kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-        
-    - name: Finally, deploy datadog-agent via helm chart
-      run: |
-        cd panoptichain/terraform
-        terraform init
-        terraform apply -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+    # - name: Deploy PoS devnet to isolated GKE namespace
+    #   run: |
+    #     mkdir -p ~/.kube
+    #     echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
+    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
+    #     cd polygon-devnets/kubernetes/pos
+    #     kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+    # 
+    # - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
+    #   run: |
+    #     cd panoptichain
+    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
+    #     kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+    # 
+    # - name: Finally, deploy datadog-agent via helm chart
+    #   run: |
+    #     cd panoptichain/terraform
+    #     terraform init
+    #     terraform apply -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+    # 
+    # - name: Auto-apply load and report any regressions here
+    #   run: |
+    #     MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
+    #     DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
+    #     DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
+    # 
+    #     end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
+    # 
+    #     while [ $(date +'%M') -lt $end_minute ]; do
+    #       STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
+    #                 -H "Content-Type: application/json" \
+    #                 -H "DD-API-KEY: ${DATADOG_API_KEY}" \
+    #                 -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
+    #                 -s \
+    #                 | jq -r '.overall_state')
+    #       echo "K8S DEVNET HEALTH STATUS: $STATUS"
+    #       echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
+    #       sleep 60
+    #     done
+    # 
+    #   # After stress tests, cleanup all ephemeral K8S devnet resources    
+    # - name: Remove panoptichain, prometheus, and grafana resources
+    #   run: |
+    #     cd panoptichain
+    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
+    #     kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 
-    - name: Auto-apply load and report any regressions here
-      run: |
-        MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
-        DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
-        DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
-
-        end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
-
-        while [ $(date +'%M') -lt $end_minute ]; do
-          STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
-                    -H "Content-Type: application/json" \
-                    -H "DD-API-KEY: ${DATADOG_API_KEY}" \
-                    -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
-                    -s \
-                    | jq -r '.overall_state')
-          echo "K8S DEVNET HEALTH STATUS: $STATUS"
-          echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
-          sleep 60
-        done
-        
-    - name: After stress tests, cleanup all ephemeral K8S devnet resources
-      run: |
-        # remove panoptichain, prometheus, and grafana resources
-        cd panoptichain
-        export KUBECONFIG=~/.kube/regression-cluster.yaml
-        kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-        
-        # remove all datadog agent resources
+    - name: Remove all datadog agent resources
+      run: |        
         cd panoptichain/terraform
         terraform init
         terraform delete -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
-        
-        # finally, remove all pos devnet resources to return to clean slate GKE environment
-        export KUBECONFIG=~/.kube/regression-cluster.yaml
+
+    - name: Finally, remove pos devnet resources and return to clean slate GKE environment
+      run: |     
         cd polygon-devnets/kubernetes/pos
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
         kubectl delete -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         mkdir -p ~/.kube
         echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
-        export KUBECONFIG=~/.kube/regression-cluster.yaml
+    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
     #     cd polygon-devnets/kubernetes/pos
     #     kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
     # 
@@ -102,16 +102,22 @@ jobs:
       run: |
         cd panoptichain/terraform
         retries=3
-        delay=5
+        delay=180
         count=0
         while [ $count -lt $retries ]; do
           terraform init
-          terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${DATADOG_API_KEY}" -var="coralogix_api_key=${CORALOGIX_API_KEY}"
-          if [ $? -eq 0 ]; then
+          destroy_output=$(terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${DATADOG_API_KEY}" -var="coralogix_api_key=${CORALOGIX_API_KEY}" 2>&1)
+          if echo "$destroy_output" | grep -q "Still destroying"; then
+            echo "Destroy operation is still in progress. Retrying in $delay seconds..."
+            sleep $delay
+          elif echo "$destroy_output" | grep -q "Apply complete! Resources: 0 added, 0 changed, 1 destroyed"; then
+            echo "Datadog agent resources successfully destroyed."
             break
+          else
+            echo "Destroy operation failed. Retrying in $delay seconds..."
+            count=$((count+1))
+            sleep $delay
           fi
-          count=$((count+1))
-          sleep $delay
         done
     
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         echo '${{ secrets.GOOGLE_CREDENTIALS }}' > /tmp/credentials.json
         echo "$(< /tmp/credentials.json | head -c 10)"
-        gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
+        # gcloud auth activate-service-account --key-file=/tmp/credentials.json ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com --project=prj-polygonlabs-devtools-dev
         gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
         
         cd polygon-devnets/kubernetes/pos

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -85,4 +85,5 @@ jobs:
                     | jq -r '.overall_state')
           echo "K8S DEVNET HEALTH STATUS: $STATUS"
           current_minute=$(date +'%M')
+          sleep 60
         done

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -52,48 +52,48 @@ jobs:
       run: |
         mkdir -p ~/.kube
         echo "${{ secrets.GKE_CLUSTER_CREDENTIALS }}" > ~/.kube/regression-cluster.yaml
-    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
-    #     cd polygon-devnets/kubernetes/pos
-    #     kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-    # 
-    # - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
-    #   run: |
-    #     cd panoptichain
-    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
-    #     kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
-    # 
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        cd polygon-devnets/kubernetes/pos
+        kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+    
+    - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
+      run: |
+        cd panoptichain
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+    
     - name: Finally, deploy datadog-agent via helm chart
       run: |
         cd panoptichain/terraform
         terraform init
         terraform apply -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
     
-    # - name: Auto-apply load and report any regressions here
-    #   run: |
-    #     MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
-    #     DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
-    #     DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
-    # 
-    #     end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
-    # 
-    #     while [ $(date +'%M') -lt $end_minute ]; do
-    #       STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
-    #                 -H "Content-Type: application/json" \
-    #                 -H "DD-API-KEY: ${DATADOG_API_KEY}" \
-    #                 -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
-    #                 -s \
-    #                 | jq -r '.overall_state')
-    #       echo "K8S DEVNET HEALTH STATUS: $STATUS"
-    #       echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
-    #       sleep 60
-    #     done
+    - name: Auto-apply load and report any regressions here
+      run: |
+        MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
+        DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
+        DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
     
-    #   # After stress tests, cleanup all ephemeral K8S devnet resources    
-    # - name: Remove panoptichain, prometheus, and grafana resources
-    #   run: |
-    #     cd panoptichain
-    #     export KUBECONFIG=~/.kube/regression-cluster.yaml
-    #     kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
+    
+        while [ $(date +'%M') -lt $end_minute ]; do
+          STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
+                    -H "Content-Type: application/json" \
+                    -H "DD-API-KEY: ${DATADOG_API_KEY}" \
+                    -H "DD-APPLICATION-KEY: ${DATADOG_APP_KEY}" \
+                    -s \
+                    | jq -r '.overall_state')
+          echo "K8S DEVNET HEALTH STATUS: $STATUS"
+          echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
+          sleep 60
+        done
+    
+      # After stress tests, cleanup all ephemeral K8S devnet resources    
+    - name: Remove panoptichain, prometheus, and grafana resources
+      run: |
+        cd panoptichain
+        export KUBECONFIG=~/.kube/regression-cluster.yaml
+        kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 
     - name: Remove all Datadog agent resources 
       env:

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -1,8 +1,14 @@
 name: K8S DEVNET - REGRESSION DETECTOR
 on:
-  push:
-  release:
-    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      bor_version:
+        description: 'bor version (default: latest)'
+        required: false
+        default: 'latest'
+      bake_time:
+        description: 'bake time in minutes'
+        required: true
 
 # forward-looking, devs could manually trigger this action (via github UI) and easily spin up / stress test devnets for ad hoc testing
 jobs:
@@ -76,9 +82,10 @@ jobs:
         MONITOR_ID="140974014"  # K8S DEVNET: COMPOSITE MONITOR ID
         DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
         DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
-    
-        end_minute=$(( $(date +'%M') + 10))  # Calculate the end minute, bake time, make configurable..
-    
+
+        bake_time="${{ github.event.inputs.bake_time }}"
+        end_minute=$(( $(date +'%M') + bake_time))
+
         while [ $(date +'%M') -lt $end_minute ]; do
           STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
                     -H "Content-Type: application/json" \

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -95,7 +95,7 @@ jobs:
     #     export KUBECONFIG=~/.kube/regression-cluster.yaml
     #     kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 
-    - name: Remove all Datadog agent resources
+    - name: Remove all Datadog agent resources 
       env:
         DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -27,10 +27,10 @@ jobs:
         project_id: 'prj-polygonlabs-devtools-dev'
         service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
 
-    - name: Install kubectl
+    - name: Install kubectl and gcloud kubectl auth plugin
       run: |
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
-        && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+        && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && gcloud components install gke-gcloud-auth-plugin
 
     - name: Install tomlq for config file preparation
       run: |

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -21,6 +21,12 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.17
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v1
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
+      with:
+        version: '>= 363.0.0'
     - name: Install kubectl
       run: |
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
@@ -38,9 +44,20 @@ jobs:
     - uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
-    - name: Install tomlq
+    - name: Clone, build, and load k8s devnet images
       run: |
-        gcloud container clusters list
+        eval `ssh-agent -s`
+        ssh-add - <<< '${{ secrets.SSH_PRIVATE_KEY }}'
+        git clone git@github.com:maticnetwork/polygon-devnets.git
+        cd polygon-devnets/docker/pos
+        make all DEV=true K8S_ENV=true K8S_NS=test
+        IMAGES=$(docker images -q)
+        echo $IMAGES
+        gcloud auth configure-docker europe-west2-docker.pkg.dev -q
+        for IMAGE_ID in $IMAGES; do
+          IMAGE_NAME=$(docker inspect --format='{{index .RepoTags 0}}' $IMAGE_ID)
+          sudo -u $USER docker push "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/container/${IMAGE_NAME}:latest"
+        done
     # - name: Create local k8s cluster
     #   run: |
     #     kind create cluster --name regression-tester --config .github/workflows/kind-config.yaml.sample

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -10,7 +10,6 @@ on:
         description: 'bake time in minutes'
         required: true
 
-# forward-looking, devs could manually trigger this action (via github UI) and easily spin up / stress test devnets for ad hoc testing
 jobs:
   deploy_devnet:
     runs-on: ubuntu-latest

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Deploy PoS devnet to isolated GKE namespace
       run: |
         cd polygon-devnets/kubernetes/pos
+        gcloud container clusters get-credentials ci-cluster-1 --region europe-west2
         # metrics must be tagged by unique namespace (devnet name / pre-release id)
         # deployment must also create custom monitors by namespace
         kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -1,4 +1,4 @@
-name: K8S DEVNET - REGRESSION DETECTOR
+name: K8S DEVNETS - REGRESSION DETECTOR
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -100,14 +100,13 @@ jobs:
       retries: 3
       delay: 5
       until: tf_result is not failed
-      ansible.builtin.shell:
-        cmd: |
+      run: |    
           cd panoptichain/terraform
           terraform init
           terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
 
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment
-      run: |     
+      run: |
         cd polygon-devnets/kubernetes/pos
         export KUBECONFIG=~/.kube/regression-cluster.yaml
         kubectl delete -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [prereleased]
 
+# forward-looking, devs could manually trigger this action (via github UI) and easily spin up / stress test devnets for ad hoc testing
 jobs:
   deploy_devnet:
     runs-on: ubuntu-latest
@@ -73,10 +74,9 @@ jobs:
         DATADOG_API_KEY="${{ secrets.DATADOG_API_KEY }}"
         DATADOG_APP_KEY="${{ secrets.DATADOG_APP_KEY }}"
 
-        current_minute=$(date +'%M')
-        end_minute=$((current_minute + 10))
-        
-        while [ $current_minute -lt $end_minute ]; do
+        end_minute=$(( $(date +'%M') + 1))  # Calculate the end minute
+
+        while [ $(date +'%M') -lt $end_minute ]; do
           STATUS=$(curl -X GET "https://api.datadoghq.com/api/v1/monitor/${MONITOR_ID}" \
                     -H "Content-Type: application/json" \
                     -H "DD-API-KEY: ${DATADOG_API_KEY}" \
@@ -85,7 +85,6 @@ jobs:
                     | jq -r '.overall_state')
           echo "K8S DEVNET HEALTH STATUS: $STATUS"
           echo "Review your devnet health dashboard here: https://app.datadoghq.com/dashboard/fqu-nh2-bzd?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1709886652761&to_ts=1709890252761&live=true"
-          current_minute=$(date +'%M')
           sleep 60
         done
         

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -24,6 +24,8 @@ jobs:
     - uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+        project_id: 'prj-polygonlabs-devtools-dev'
+        service_account: 'ci-k8s-cluster@prj-polygonlabs-devtools-dev.iam.gserviceaccount.com'
 
     - name: Install kubectl
       run: |

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -55,18 +55,21 @@ jobs:
         export KUBECONFIG=~/.kube/regression-cluster.yaml
         cd polygon-devnets/kubernetes/pos
         kubectl apply -k overlays/gcr --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        sleep 60
     
     - name: Deploy panoptichain, prometheus, grafana stack for metric tracking
       run: |
         cd panoptichain
         export KUBECONFIG=~/.kube/regression-cluster.yaml
         kubectl apply -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
+        sleep 60
     
     - name: Finally, deploy datadog-agent via helm chart
       run: |
         cd panoptichain/terraform
         terraform init
         terraform apply -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
+        sleep 60
     
     - name: Auto-apply load and report any regressions here
       run: |

--- a/.github/workflows/k8s-regression-tester.yml
+++ b/.github/workflows/k8s-regression-tester.yml
@@ -95,16 +95,25 @@ jobs:
     #     export KUBECONFIG=~/.kube/regression-cluster.yaml
     #     kubectl delete -f grafana-service.yaml,panoptichain-service.yaml,prometheus-service.yaml,grafana-deployment.yaml,grafana-claim0-persistentvolumeclaim.yaml,panoptichain-deployment.yaml,prometheus-deployment.yaml,prometheus-claim0-persistentvolumeclaim.yaml --namespace=pos --context=gke_prj-polygonlabs-devtools-dev_europe-west2_ci-cluster-1
 
-    - name: Remove all datadog agent resources
-      register: tf_result
-      retries: 3
-      delay: 5
-      until: tf_result is not failed
-      run: |    
-          cd panoptichain/terraform
+    - name: Remove all Datadog agent resources
+      env:
+        DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
+      run: |
+        cd panoptichain/terraform
+        retries=3
+        delay=5
+        count=0
+        while [ $count -lt $retries ]; do
           terraform init
-          terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${{ secrets.DATADOG_API_KEY }}" -var="coralogix_api_key=${{ secrets.CORALOGIX_API_KEY }}"
-
+          terraform destroy -auto-approve -target=helm_release.datadog_agent -var="datadog_api_key=${DATADOG_API_KEY}" -var="coralogix_api_key=${CORALOGIX_API_KEY}"
+          if [ $? -eq 0 ]; then
+            break
+          fi
+          count=$((count+1))
+          sleep $delay
+        done
+    
     - name: Finally, remove pos devnet resources and return to clean slate GKE environment
       run: |
         cd polygon-devnets/kubernetes/pos

--- a/.github/workflows/make-k8s-images.yml
+++ b/.github/workflows/make-k8s-images.yml
@@ -2,7 +2,7 @@ name: Image Sync
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/30 * * * *'
 
 jobs:
   sync-images:

--- a/.github/workflows/make-k8s-images.yml
+++ b/.github/workflows/make-k8s-images.yml
@@ -1,9 +1,8 @@
 name: Image Sync
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/15 * * * *'
 
 jobs:
   sync-images:


### PR DESCRIPTION
Description
introduce low-cost, virtualized posv1 kubernetes-based devnets (ephemeral for regression testing purposes of new client version [imagine integrated as part of final code confidence checks before public release of heimdall / bor / erigon / zk / etc ])

Purpose
maximum developer simplicity: full dev ssh access to pos devnet virtual machines, automatic stress and load tests applied to ephemeral devnets via polycli, configurable bake time by devs, and much more.